### PR TITLE
Update and rename 50741.json to eip155-50741.json

### DIFF
--- a/_data/chains/eip155-50741.json
+++ b/_data/chains/eip155-50741.json
@@ -1,6 +1,6 @@
 {
   "name": "GBGC Mainnet",
-  "chain": "GBGC",
+  "chain": "EIP155",
   "rpc": ["https://mainnet-rpc.gbgcscan.com/"],
   "faucets": [],
   "nativeCurrency": {


### PR DESCRIPTION
- Renamed the JSON file to follow the naming convention for EIP-155 chains.
- Updated the file to ensure it adheres to the required schema.
- Included necessary fields such as chainId, rpc URLs, nativeCurrency details, and explorers.